### PR TITLE
Feature/5 parser factory implementation

### DIFF
--- a/src/main/java/com/core/data_pipeline_platform/domain/parse/service/BinDataParser.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/parse/service/BinDataParser.java
@@ -57,6 +57,11 @@ public class BinDataParser implements DataParser {
         }
     }
 
+    @Override
+    public FileType getSupportedFileType() {
+        return FileType.BIN;
+    }
+
     private String readString(DataInputStream dataStream) throws IOException {
         int length = dataStream.readInt();
         if (length == 0) return "";

--- a/src/main/java/com/core/data_pipeline_platform/domain/parse/service/CsvDataParser.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/parse/service/CsvDataParser.java
@@ -64,4 +64,9 @@ public class CsvDataParser implements DataParser{
         }
         
     }
+
+    @Override
+    public FileType getSupportedFileType() {
+        return FileType.CSV;
+    }
 }

--- a/src/main/java/com/core/data_pipeline_platform/domain/parse/service/DataParser.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/parse/service/DataParser.java
@@ -2,7 +2,6 @@ package com.core.data_pipeline_platform.domain.parse.service;
 
 import com.core.data_pipeline_platform.domain.file.enums.FileType;
 
-
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +12,11 @@ public interface DataParser {
       * - fileType: 구현체가 지원하는 타입이어야 하며, 불일치 시 400을 던진다.
       * - inputStream: null 불가. 호출자가 생명주기/close를 관리한다.
       */
-    List<Map<String, Object>> parseData(FileType fileType, InputStream inputStream);
+    List<Map<String, Object>>  parseData(FileType fileType, InputStream inputStream);
+
+    /**
+     * 구현체가 지원하는 파일 타입을 반환한다.
+     */
+    FileType getSupportedFileType();
 
 }

--- a/src/main/java/com/core/data_pipeline_platform/domain/parse/service/DataParsingService.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/parse/service/DataParsingService.java
@@ -1,0 +1,44 @@
+package com.core.data_pipeline_platform.domain.parse.service;
+
+import com.core.data_pipeline_platform.domain.file.entity.FileEntity;
+import com.core.data_pipeline_platform.domain.file.enums.FileType;
+import com.core.data_pipeline_platform.domain.parse.entity.ParsedDataEntity;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class DataParsingService {
+
+    private final ParserFactory parserFactory;
+    private final ObjectMapper objectMapper;
+
+    public ParsedDataEntity parseAndSave(FileType fileType, InputStream inputStream, FileEntity file) {
+        try {
+            DataParser parser = parserFactory.getParser(fileType);
+            List<Map<String, Object>> maps = parser.parseData(fileType, inputStream);
+
+            String jsonData = objectMapper.writeValueAsString(maps);
+
+            return ParsedDataEntity.builder()
+                    .file(file)
+                    .data(jsonData)
+                    .build();
+
+        }catch (JsonProcessingException e){
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파싱 실패");
+        }
+
+    }
+
+
+
+}

--- a/src/main/java/com/core/data_pipeline_platform/domain/parse/service/JsonDataParser.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/parse/service/JsonDataParser.java
@@ -40,4 +40,9 @@ public class JsonDataParser implements DataParser {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Json 파싱 실패");
         }
     }
+
+    @Override
+    public FileType getSupportedFileType() {
+        return FileType.JSON;
+    }
 }

--- a/src/main/java/com/core/data_pipeline_platform/domain/parse/service/ParserFactory.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/parse/service/ParserFactory.java
@@ -1,7 +1,9 @@
 package com.core.data_pipeline_platform.domain.parse.service;
 
 import com.core.data_pipeline_platform.domain.file.enums.FileType;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Map;
@@ -22,7 +24,11 @@ public class ParserFactory {
     }
 
     public DataParser getParser(FileType fileType) {
-        return parsers.get(fileType);
+        DataParser parser = parsers.get(fileType);
+        if(parser == null){
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 파일형식입니다.");
+        }
+        return parser;
     }
 
 }

--- a/src/main/java/com/core/data_pipeline_platform/domain/parse/service/ParserFactory.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/parse/service/ParserFactory.java
@@ -1,0 +1,28 @@
+package com.core.data_pipeline_platform.domain.parse.service;
+
+import com.core.data_pipeline_platform.domain.file.enums.FileType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class ParserFactory {
+
+    private final Map<FileType, DataParser> parsers;
+
+    public ParserFactory(List<DataParser> parserList) {
+        this.parsers = parserList.stream()
+                .collect(Collectors.toMap(
+                        DataParser::getSupportedFileType,
+                        parser -> parser
+                ));
+
+    }
+
+    public DataParser getParser(FileType fileType) {
+        return parsers.get(fileType);
+    }
+
+}

--- a/src/main/java/com/core/data_pipeline_platform/domain/parse/service/XmlDataParser.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/parse/service/XmlDataParser.java
@@ -77,6 +77,11 @@ public class XmlDataParser implements DataParser {
         }
     }
 
+    @Override
+    public FileType getSupportedFileType() {
+        return FileType.XML;
+    }
+
     private Object getElementContent(Element element, String tagName) {
         NodeList nodes = element.getElementsByTagName(tagName);
         if (nodes.getLength() == 0) {

--- a/src/test/java/com/core/data_pipeline_platform/domain/parse/service/ParserFactoryTest.java
+++ b/src/test/java/com/core/data_pipeline_platform/domain/parse/service/ParserFactoryTest.java
@@ -1,0 +1,50 @@
+package com.core.data_pipeline_platform.domain.parse.service;
+
+import com.core.data_pipeline_platform.domain.file.enums.FileType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ParserFactoryTest {
+
+    private ParserFactory parserFactory;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        ArrayList<DataParser> parsers = new ArrayList<>();
+        parsers.add(new JsonDataParser(objectMapper));
+        parserFactory = new ParserFactory(parsers);
+    }
+
+    @Test
+    void getParser_invalid_fileType() {
+        // Given
+        FileType invalidFileType = FileType.XML;
+
+        // When & Then
+        assertThrows(ResponseStatusException.class, () -> parserFactory.getParser(invalidFileType));
+    }
+
+    @Test
+    void getParser_validFileType() {
+        // Given
+        FileType validFileType = FileType.JSON;
+
+        // When
+        DataParser result = parserFactory.getParser(validFileType);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(FileType.JSON, result.getSupportedFileType());
+    }
+
+}


### PR DESCRIPTION
## 개요

###  기능
- **ParserFactory 클래스 추가**: 파일 타입별 파서 관리를 위한 팩토리 패턴 구현
- **DataParser 인터페이스 확장**: `getSupportedFileType()` 메서드 추가

Related to #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 파일 유형(BIN, CSV, JSON, XML)을 명시적으로 지원하는 파서들을 등록·관리해 자동으로 적합한 파서를 선택합니다.
  - 업로드된 파일을 구조화된 JSON 형태로 변환·저장하는 파싱 서비스가 추가되었습니다.
  - 지원하지 않는 파일 유형 요청 시 명확한 오류 응답(HTTP 400, “잘못된 파일형식입니다.”)을 반환합니다.
- **테스트**
  - 파서 팩토리 동작(유효/무효 파일형식 처리)을 검증하는 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->