### PR TITLE
Feature/6 parsed data crud

### DIFF
--- a/src/main/java/com/core/data_pipeline_platform/domain/file/service/FileUploadService.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/file/service/FileUploadService.java
@@ -38,9 +38,9 @@ public class FileUploadService {
 
             ParsedDataEntity parsedDataEntity = dataParsingService
                     .parseToEntity(fileType, file.getInputStream(), savedFile);
-            ParsedDataEntity savedEntity = parsedDataRepository.save(parsedDataEntity);
+            parsedDataRepository.save(parsedDataEntity);
 
-            return savedEntity.getId();
+            return savedFile.getId();
         } catch (DataIntegrityViolationException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 존재하는 파일 이름입니다.");
         } catch (IOException e) {

--- a/src/main/java/com/core/data_pipeline_platform/domain/parse/controller/ParsedDataController.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/parse/controller/ParsedDataController.java
@@ -1,0 +1,60 @@
+package com.core.data_pipeline_platform.domain.parse.controller;
+
+import com.core.data_pipeline_platform.domain.parse.dto.ParsedDataResponse;
+import com.core.data_pipeline_platform.domain.parse.entity.ParsedDataEntity;
+import com.core.data_pipeline_platform.domain.parse.service.ParsedDataService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/parsed-data")
+@RequiredArgsConstructor
+public class ParsedDataController {
+
+    private final ParsedDataService parsedDataService;
+
+    /**
+     * 모든 파싱된 데이터 조회 (페이징)
+     */
+    @GetMapping
+    public ResponseEntity<Page<ParsedDataEntity>> getAllParsedData(Pageable pageable) {
+        Page<ParsedDataEntity> parsedData = parsedDataService.getAllParsedData(pageable);
+        return ResponseEntity.ok(parsedData);
+    }
+
+    /**
+     * 파일 ID로 파싱된 데이터 조회
+     */
+    @GetMapping("/{fileId}")
+    public ResponseEntity<ParsedDataResponse> getParsedDataByFileId(@PathVariable Long fileId) {
+        ParsedDataEntity entity = parsedDataService.getParsedDataByFileId(fileId);
+        List<Map<String, Object>> data = parsedDataService.getParsedDataAsMap(fileId);
+        
+        ParsedDataResponse response = ParsedDataResponse.from(entity, data);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 파싱된 데이터 삭제
+     */
+    @DeleteMapping("/{fileId}")
+    public ResponseEntity<Void> deleteParsedData(@PathVariable Long fileId) {
+        parsedDataService.deleteParsedData(fileId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 파싱된 데이터 개수 조회
+     */
+    @GetMapping("/count")
+    public ResponseEntity<Long> getParsedDataCount() {
+        long count = parsedDataService.getParsedDataCount();
+        return ResponseEntity.ok(count);
+    }
+}

--- a/src/main/java/com/core/data_pipeline_platform/domain/parse/dto/ParsedDataResponse.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/parse/dto/ParsedDataResponse.java
@@ -1,0 +1,30 @@
+package com.core.data_pipeline_platform.domain.parse.dto;
+
+import com.core.data_pipeline_platform.domain.file.entity.FileEntity;
+import com.core.data_pipeline_platform.domain.parse.entity.ParsedDataEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class ParsedDataResponse {
+    private Long id;
+    private Long fileId;
+    private String fileName;
+    private String fileType;
+    private List<Map<String, Object>> data;
+
+    public static ParsedDataResponse from(ParsedDataEntity entity, List<Map<String, Object>> parsedData) {
+        FileEntity file = entity.getFile();
+        return ParsedDataResponse.builder()
+            .id(entity.getId())
+            .fileId(file.getId())
+            .fileName(file.getOriginName())
+            .fileType(file.getFileType().name())
+            .data(parsedData)
+            .build();
+    }
+}

--- a/src/main/java/com/core/data_pipeline_platform/domain/parse/entity/ParsedDataEntity.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/parse/entity/ParsedDataEntity.java
@@ -1,0 +1,26 @@
+package com.core.data_pipeline_platform.domain.parse.entity;
+
+import com.core.data_pipeline_platform.domain.file.entity.FileEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ParsedDataEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    private FileEntity file;
+
+    @Column(columnDefinition = "json", nullable = false)
+    private String data;
+}

--- a/src/main/java/com/core/data_pipeline_platform/domain/parse/repository/ParsedDataRepository.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/parse/repository/ParsedDataRepository.java
@@ -1,0 +1,10 @@
+package com.core.data_pipeline_platform.domain.parse.repository;
+
+import com.core.data_pipeline_platform.domain.parse.entity.ParsedDataEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ParsedDataRepository extends JpaRepository<ParsedDataEntity, Long> {
+    Optional<ParsedDataEntity> findByFileId(Long fileId);
+}

--- a/src/main/java/com/core/data_pipeline_platform/domain/parse/service/DataParsingService.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/parse/service/DataParsingService.java
@@ -21,7 +21,7 @@ public class DataParsingService {
     private final ParserFactory parserFactory;
     private final ObjectMapper objectMapper;
 
-    public ParsedDataEntity parseAndSave(FileType fileType, InputStream inputStream, FileEntity file) {
+    public ParsedDataEntity parseToEntity(FileType fileType, InputStream inputStream, FileEntity file) {
         try {
             DataParser parser = parserFactory.getParser(fileType);
             List<Map<String, Object>> maps = parser.parseData(fileType, inputStream);

--- a/src/main/java/com/core/data_pipeline_platform/domain/parse/service/ParsedDataService.java
+++ b/src/main/java/com/core/data_pipeline_platform/domain/parse/service/ParsedDataService.java
@@ -1,0 +1,66 @@
+package com.core.data_pipeline_platform.domain.parse.service;
+
+import com.core.data_pipeline_platform.domain.parse.entity.ParsedDataEntity;
+import com.core.data_pipeline_platform.domain.parse.repository.ParsedDataRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ParsedDataService {
+
+    private final ParsedDataRepository parsedDataRepository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 모든 파싱된 데이터 조회 (페이징)
+     */
+    public Page<ParsedDataEntity> getAllParsedData(Pageable pageable) {
+        return parsedDataRepository.findAll(pageable);
+    }
+
+    /**
+     * 파일 ID로 파싱된 데이터 조회
+     */
+    public ParsedDataEntity getParsedDataByFileId(Long fileId) {
+        return parsedDataRepository.findByFileId(fileId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "파싱된 데이터를 찾을 수 없습니다."));
+    }
+
+    /**
+     * 파싱된 데이터의 JSON 데이터를 List<Map>으로 변환하여 반환
+     */
+    public List<Map<String, Object>> getParsedDataAsMap(Long fileId) {
+        ParsedDataEntity parsedData = getParsedDataByFileId(fileId);
+        
+        try {
+            return objectMapper.readValue(parsedData.getData(), new TypeReference<>() {});
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "데이터 변환 실패");
+        }
+    }
+
+    /**
+     * 파싱된 데이터 삭제
+     */
+    public void deleteParsedData(Long fileId) {
+        ParsedDataEntity parsedData = getParsedDataByFileId(fileId);
+        parsedDataRepository.delete(parsedData);
+    }
+
+    /**
+     * 파싱된 데이터 개수 조회
+     */
+    public long getParsedDataCount() {
+        return parsedDataRepository.count();
+    }
+}

--- a/src/test/java/com/core/data_pipeline_platform/domain/parse/controller/ParsedDataControllerTest.java
+++ b/src/test/java/com/core/data_pipeline_platform/domain/parse/controller/ParsedDataControllerTest.java
@@ -1,0 +1,135 @@
+package com.core.data_pipeline_platform.domain.parse.controller;
+
+import com.core.data_pipeline_platform.domain.file.entity.FileEntity;
+import com.core.data_pipeline_platform.domain.file.enums.FileType;
+import com.core.data_pipeline_platform.domain.parse.entity.ParsedDataEntity;
+import com.core.data_pipeline_platform.domain.parse.service.ParsedDataService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ParsedDataController.class)
+@DisplayName("ParsedDataController 테스트")
+class ParsedDataControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ParsedDataService parsedDataService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private FileEntity mockFile;
+    private ParsedDataEntity mockParsedData;
+    private List<Map<String, Object>> mockData;
+
+    @BeforeEach
+    void setUp() {
+        mockFile = FileEntity.builder()
+            .id(1L)
+            .fileType(FileType.JSON)
+            .originName("test.json")
+            .build();
+
+        mockParsedData = ParsedDataEntity.builder()
+            .id(1L)
+            .file(mockFile)
+            .data("[{\"name\":\"John\",\"age\":25}]")
+            .build();
+
+        mockData = Arrays.asList(
+            Map.of("name", "John", "age", 25),
+            Map.of("name", "Jane", "age", 30)
+        );
+    }
+
+    @Test
+    @DisplayName("모든 파싱된 데이터 조회 - 성공")
+    void getAllParsedData_Success() throws Exception {
+        // Given
+        List<ParsedDataEntity> entities = Arrays.asList(mockParsedData);
+        Page<ParsedDataEntity> page = new PageImpl<>(entities, PageRequest.of(0, 10), 1);
+
+        given(parsedDataService.getAllParsedData(any()))
+            .willReturn(page);
+
+        // When & Then
+        mockMvc.perform(get("/api/parsed-data")
+                .param("page", "0")
+                .param("size", "10")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content[0].id").value(1))
+            .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    @DisplayName("파일 ID로 파싱된 데이터 조회 - 성공")
+    void getParsedDataByFileId_Success() throws Exception {
+        // Given
+        Long fileId = 1L;
+        given(parsedDataService.getParsedDataByFileId(fileId))
+            .willReturn(mockParsedData);
+        given(parsedDataService.getParsedDataAsMap(fileId))
+            .willReturn(mockData);
+
+        // When & Then
+        mockMvc.perform(get("/api/parsed-data/{fileId}", fileId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.fileId").value(1))
+            .andExpect(jsonPath("$.fileName").value("test.json"))
+            .andExpect(jsonPath("$.fileType").value("JSON"))
+            .andExpect(jsonPath("$.data").isArray())
+            .andExpect(jsonPath("$.data[0].name").value("John"));
+    }
+
+    @Test
+    @DisplayName("파싱된 데이터 삭제 - 성공")
+    void deleteParsedData_Success() throws Exception {
+        // Given
+        Long fileId = 1L;
+
+        // When & Then
+        mockMvc.perform(delete("/api/parsed-data/{fileId}", fileId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("파싱된 데이터 개수 조회 - 성공")
+    void getParsedDataCount_Success() throws Exception {
+        // Given
+        long count = 5L;
+        given(parsedDataService.getParsedDataCount())
+            .willReturn(count);
+
+        // When & Then
+        mockMvc.perform(get("/api/parsed-data/count")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").value(5));
+    }
+}

--- a/src/test/java/com/core/data_pipeline_platform/domain/parse/service/ParsedDataServiceTest.java
+++ b/src/test/java/com/core/data_pipeline_platform/domain/parse/service/ParsedDataServiceTest.java
@@ -1,0 +1,187 @@
+package com.core.data_pipeline_platform.domain.parse.service;
+
+import com.core.data_pipeline_platform.domain.file.entity.FileEntity;
+import com.core.data_pipeline_platform.domain.file.enums.FileType;
+import com.core.data_pipeline_platform.domain.parse.entity.ParsedDataEntity;
+import com.core.data_pipeline_platform.domain.parse.repository.ParsedDataRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ParsedDataService 테스트")
+class ParsedDataServiceTest {
+
+    @Mock
+    private ParsedDataRepository parsedDataRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private ParsedDataService parsedDataService;
+
+    private FileEntity mockFile;
+    private ParsedDataEntity mockParsedData;
+    private List<Map<String, Object>> mockData;
+
+    @BeforeEach
+    void setUp() {
+        mockFile = FileEntity.builder()
+            .id(1L)
+            .fileType(FileType.JSON)
+            .originName("test.json")
+            .build();
+
+        mockParsedData = ParsedDataEntity.builder()
+            .id(1L)
+            .file(mockFile)
+            .data("[{\"name\":\"John\",\"age\":25}]")
+            .build();
+
+        mockData = Arrays.asList(
+            Map.of("name", "John", "age", 25),
+            Map.of("name", "Jane", "age", 30)
+        );
+    }
+
+    @Test
+    @DisplayName("모든 파싱된 데이터 조회 - 성공")
+    void getAllParsedData_Success() {
+        // Given
+        Pageable pageable = PageRequest.of(0, 10);
+        List<ParsedDataEntity> entities = Arrays.asList(mockParsedData);
+        Page<ParsedDataEntity> expectedPage = new PageImpl<>(entities, pageable, 1);
+
+        given(parsedDataRepository.findAll(pageable))
+            .willReturn(expectedPage);
+
+        // When
+        Page<ParsedDataEntity> result = parsedDataService.getAllParsedData(pageable);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getId()).isEqualTo(1L);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+
+        then(parsedDataRepository).should().findAll(pageable);
+    }
+
+    @Test
+    @DisplayName("파일 ID로 파싱된 데이터 조회 - 성공")
+    void getParsedDataByFileId_Success() {
+        // Given
+        Long fileId = 1L;
+        given(parsedDataRepository.findByFileId(fileId))
+            .willReturn(Optional.of(mockParsedData));
+
+        // When
+        ParsedDataEntity result = parsedDataService.getParsedDataByFileId(fileId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getFile().getId()).isEqualTo(1L);
+
+        then(parsedDataRepository).should().findByFileId(fileId);
+    }
+
+    @Test
+    @DisplayName("파일 ID로 파싱된 데이터 조회 - 데이터 없음")
+    void getParsedDataByFileId_NotFound() {
+        // Given
+        Long fileId = 999L;
+        given(parsedDataRepository.findByFileId(fileId))
+            .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> parsedDataService.getParsedDataByFileId(fileId))
+            .isInstanceOf(ResponseStatusException.class)
+            .satisfies(ex -> {
+                ResponseStatusException responseEx = (ResponseStatusException) ex;
+                assertThat(responseEx.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+                assertThat(responseEx.getReason()).isEqualTo("파싱된 데이터를 찾을 수 없습니다.");
+            });
+
+        then(parsedDataRepository).should().findByFileId(fileId);
+    }
+
+    @Test
+    @DisplayName("파싱된 데이터를 Map으로 변환 - 성공")
+    void getParsedDataAsMap_Success() throws Exception {
+        // Given
+        Long fileId = 1L;
+        given(parsedDataRepository.findByFileId(fileId))
+            .willReturn(Optional.of(mockParsedData));
+        given(objectMapper.readValue(any(String.class), any(com.fasterxml.jackson.core.type.TypeReference.class)))
+            .willReturn(mockData);
+
+        // When
+        List<Map<String, Object>> result = parsedDataService.getParsedDataAsMap(fileId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).get("name")).isEqualTo("John");
+        assertThat(result.get(1).get("name")).isEqualTo("Jane");
+
+        then(parsedDataRepository).should().findByFileId(fileId);
+        then(objectMapper).should().readValue(any(String.class), any(com.fasterxml.jackson.core.type.TypeReference.class));
+    }
+
+    @Test
+    @DisplayName("파싱된 데이터 삭제 - 성공")
+    void deleteParsedData_Success() {
+        // Given
+        Long fileId = 1L;
+        given(parsedDataRepository.findByFileId(fileId))
+            .willReturn(Optional.of(mockParsedData));
+
+        // When
+        parsedDataService.deleteParsedData(fileId);
+
+        // Then
+        then(parsedDataRepository).should().findByFileId(fileId);
+        then(parsedDataRepository).should().delete(mockParsedData);
+    }
+
+    @Test
+    @DisplayName("파싱된 데이터 개수 조회 - 성공")
+    void getParsedDataCount_Success() {
+        // Given
+        long expectedCount = 5L;
+        given(parsedDataRepository.count())
+            .willReturn(expectedCount);
+
+        // When
+        long result = parsedDataService.getParsedDataCount();
+
+        // Then
+        assertThat(result).isEqualTo(expectedCount);
+
+        then(parsedDataRepository).should().count();
+    }
+}


### PR DESCRIPTION

## 개요
파일 업로드 시 파싱된 데이터를 저장하고, 저장된 데이터를 조회/삭제할 수 있는 CRUD API를 구현

## 기능

### 1. 파일 업로드 + 파싱 통합
- 파일 업로드와 동시에 파싱된 데이터를 `ParsedDataEntity`로 저장

### 2. 파싱된 데이터 CRUD 서비스
- `ParsedDataService`: 파싱된 데이터 조회/삭제/개수 조회 기능
- `ParsedDataRepository`: `findByFileId` 메서드 추가
- `ParsedDataResponse`: API 응답용 DTO
- JSON 데이터를 Map으로 변환하는 기능
- 페이징 지원

### 3. 파싱된 데이터 REST API
- `GET /api/parsed-data`: 전체 조회 (페이징)
- `GET /api/parsed-data/{fileId}`: 파일별 상세 조회
- `DELETE /api/parsed-data/{fileId}`: 파싱된 데이터 삭제
- `GET /api/parsed-data/count`: 개수 조회


##  API 사용 예시

```bash
# 전체 조회 (페이징)
GET /api/parsed-data?page=0&size=10

# 파일별 상세 조회
GET /api/parsed-data/1

# 파싱된 데이터 삭제
DELETE /api/parsed-data/1

# 개수 조회
GET /api/parsed-data/count
```

## 📄 응답 예시

```json
{
  "id": 1,
  "fileId": 1,
  "fileName": "sensor_data.csv",
  "fileType": "CSV",
  "data": [
    {
      "sensorId": "S001",
      "value": 25.5,
      "timestamp": "2024-01-01T10:00:00",
      "status": "active"
    }
  ]
}
```


##  관련 이슈
Closes #7  - 데이터 저장 및 CRUD API



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 업로드 시 파일을 저장한 뒤 자동으로 파싱해 파싱 결과를 저장하고 파일 ID를 반환합니다.
  - /api/parsed-data 기반: 목록 조회(페이지), 파일별 단건 조회(파싱된 데이터 포함), 삭제, 총개수 조회 API를 추가했습니다.
  - 파싱 결과를 파일 메타정보와 함께 반환하는 응답 포맷을 제공합니다.

- **Bug Fixes**
  - 파싱 관련 오류는 500으로 명확히 응답하도록 예외 처리를 정비했습니다. 중복 등 무결성 충돌은 409 유지.

- **Tests**
  - 파싱 서비스·컨트롤러·웹 계층 테스트 및 파일 업로드 테스트에 파싱 흐름을 추가/보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->